### PR TITLE
Check for empty quote output

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,6 +119,10 @@ impl OpenQuote {
                 actual,
             ));
         }
+
+        if output.is_empty() {
+            return Err(QuoteGenerationError::EmptyQuote);
+        }
         Ok(output)
     }
 
@@ -184,6 +188,7 @@ pub enum QuoteGenerationError {
     ParseInt,
     BadProvider(String),
     CannotFindTsmDir,
+    EmptyQuote,
 }
 
 impl Display for QuoteGenerationError {
@@ -204,6 +209,7 @@ impl Display for QuoteGenerationError {
             QuoteGenerationError::CannotFindTsmDir => f.write_str(
                 "Cannot find configfs-tsm directory - maybe your hardware does not support it",
             ),
+            QuoteGenerationError::EmptyQuote => f.write_str("Empty quote. This could be an authorization issue with the quote generation socket."),
         }
     }
 }


### PR DESCRIPTION
In cases where the quote generation socket refuses to produce a quote, a quote of length 0 is returned.

In this PR, we return an error in this case rather than returning an empty vector. 